### PR TITLE
Replace depreciated before_filter with before_action

### DIFF
--- a/lib/biteable.rb
+++ b/lib/biteable.rb
@@ -2,7 +2,7 @@ module Biteable
   extend ActiveSupport::Concern
 
   included do
-    before_filter :authenticate
+    before_action :authenticate
   end
 
   def authenticate


### PR DESCRIPTION
before_filter has been removed as of Rails 5.1 and is replaced with before_action - see [here](https://github.com/rails/rails/blob/49f6ce63f33b7817bcbd0cdf5f8881b63f40d9c9/actionpack/lib/abstract_controller/callbacks.rb#L191)